### PR TITLE
Update BridgeArchiver to throw an exception if running on MacOS

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/CMSSupport.git",
         "state": {
           "branch": null,
-          "revision": "9dd3ad846f09d3596ac032eff5693e40796dd6a4",
-          "version": "1.2.1"
+          "revision": "99ef4bcead679b83ee6b5414fd79992478f6c311",
+          "version": "1.2.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         .package(name: "CMSSupport",
                  url: "https://github.com/Sage-Bionetworks/CMSSupport.git",
-                 .upToNextMajor(from: "1.2.1")),
+                 .upToNextMajor(from: "1.2.3")),
         .package(name: "ZIPFoundation",
                  url: "https://github.com/weichsel/ZIPFoundation.git",
                  .upToNextMajor(from: "0.9.0"))
@@ -35,7 +35,8 @@ let package = Package(
             name: "BridgeArchiver",
             dependencies: [
                 // syoung 04/05/2022 https://bugs.swift.org/browse/SR-15196 Cannot build a binary conditionally.
-                .product(name: "CMSSupport", package: "CMSSupport", condition: .when(platforms: [.iOS])),
+                // syoung 02/21/2022 Update - Xcode 14.3 beta fixes this issue.
+                .product(name: "CMSSupport", package: "CMSSupport"),
                 "ZIPFoundation",
             ]),
         .testTarget(


### PR DESCRIPTION
This will explicitly disallow uploading from the Mac (which really, shouldn't be supported anyway except in tests that are faking the connection to S3).